### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@
 :source-highlighter: prettify
 :page-seo-title: Open Liberty tutorial
 :page-seo-description: Find out how to run microservices on Open Liberty 
-= Getting started with the Open Liberty application server
+= Deploying and packaging apps
 
 [.hidden]
 NOTE: This repository contains the guide documentation source. To view the guide in published form, view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website].

--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@
 :source-highlighter: prettify
 :page-seo-title: Open Liberty tutorial
 :page-seo-description: Find out how to run microservices on Open Liberty 
-= Deploying and packaging apps
+= Deploying and packaging applications
 
 [.hidden]
 NOTE: This repository contains the guide documentation source. To view the guide in published form, view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website].


### PR DESCRIPTION
Per discussion with Laura and Alasdair we're removing "Liberty" from the guide titles.  This guide will be part of an Open Liberty Basics category, so we are renaming it to be more descriptive and reflect the contents of the guide.