### PR TITLE
Remove logging intended for 'finish' server.xml from 'start'

### DIFF
--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -12,8 +12,6 @@
   <quickStartSecurity userName="admin" userPassword="adminpwd"/>
   <keyStore id="defaultKeyStore" password="mpKeystore"/>
 
-  <logging traceSpecification="com.ibm.ws.microprofile.health.*=all"/>
-  
   <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="getting-started.war" contextRoot="/"/>


### PR DESCRIPTION
This is the same change that I mistakenly pushed directly to OpenLiberty/master and then reverted when I realized I'd set up my remotes incorrectly.   

Sorry, my bad.