### PR TITLE
Changing packageFile to produce jar

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -39,6 +39,7 @@
         <profile>
             <id>runnable-package</id>
             <properties>
+                <package.file>${project.build.directory}/${app.name}.jar</package.file>
                 <packaging.type>runnable</packaging.type>
             </properties>
         </profile>
@@ -46,6 +47,7 @@
         <profile>
             <id>minify-runnable-package</id>
             <properties>
+                <package.file>${project.build.directory}/${app.name}.jar</package.file>
                 <packaging.type>minify,runnable</packaging.type>
             </properties>
         </profile>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -39,6 +39,7 @@
         <profile>
             <id>runnable-package</id>
             <properties>
+                <package.file>${project.build.directory}/${app.name}.jar</package.file>
                 <packaging.type>runnable</packaging.type>
             </properties>
         </profile>
@@ -46,6 +47,7 @@
         <profile>
             <id>minify-runnable-package</id>
             <properties>
+                <package.file>${project.build.directory}/${app.name}.jar</package.file>
                 <packaging.type>minify,runnable</packaging.type>
             </properties>
         </profile>


### PR DESCRIPTION
Overriding `package.file` so a .jar file will be produced when running the `runnable-package` or `minify-runnable-package` profiles (https://github.com/OpenLiberty/guide-getting-started/issues/44)