### PR TITLE
Add mp config instead of checking server name (#62)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -246,7 +246,7 @@ SystemHealth.java
 include::finish/src/main/java/io/openliberty/sample/system/SystemHealth.java[tags=**;!copyright]
 ----
 
-The [hotspot=12-24 file=1]`SystemHealth` class allows you to report on the health status
+The [hotspot=16-32 file=1]`SystemHealth` class allows you to report on the health status
 of the `system` microservice.
 
 Next, recompile the application:

--- a/finish/src/main/java/io/openliberty/sample/system/SystemHealth.java
+++ b/finish/src/main/java/io/openliberty/sample/system/SystemHealth.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019  IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,10 @@ package io.openliberty.sample.system;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
@@ -22,12 +26,16 @@ import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 @Health
 @ApplicationScoped
 public class SystemHealth implements HealthCheck {
+
+    @Inject
+    @ConfigProperty(name = "io_openliberty_guides_system_inMaintenance")
+    Provider<String> inMaintenance;
 	
     @Override
     public HealthCheckResponse call() {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named(
 		SystemResource.class.getSimpleName());
-        if (!System.getProperty("wlp.server.name").equals("GettingStartedServer")) {
+        if (inMaintenance != null && inMaintenance.get().equalsIgnoreCase("true")) {
             return builder.withData("services", "not available").down().build();
         }
         return builder.withData("services", "available").up().build();

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -7,6 +7,7 @@
         <!-- tag::mpHealth[] -->
         <feature>mpHealth-1.0</feature>
         <!-- end::mpHealth[] -->
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 
     <applicationManager autoExpand="true" />
@@ -17,6 +18,8 @@
     <!-- end::logging[] -->
     <httpEndpoint host="*" httpPort="${default.http.port}" 
         httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+    
+    <variable name="io_openliberty_guides_system_inMaintenance" value="false"/>
 
     <webApplication location="getting-started.war" contextRoot="/"/>
 </server>

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -5,6 +5,7 @@
         <feature>jsonp-1.1</feature>
         <feature>cdi-2.0</feature>
         <feature>mpMetrics-1.1</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
     <!-- end::features[] -->
 
@@ -14,6 +15,8 @@
 
     <httpEndpoint host="*" httpPort="${default.http.port}"
 	    httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+    <variable name="io_openliberty_guides_system_inMaintenance" value="false"/>
 
     <webApplication location="getting-started.war" contextRoot="/" />
 </server>


### PR DESCRIPTION
* Updated SystemHealth.java and server.xml with mpConfig feature to check inmaintenance instead of server name

* Added changes to README.adoc hotspots and updated start/server.xml

* Updated server.xml with inmaintenance variable

* Added license year for SystemHealth.java