### PR TITLE
Fix automation tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ before_script:
 - chmod +x ../scripts/travisTest.sh
 script: 
 - ../scripts/travisTest.sh
+- serverName=$(target/liberty/wlp/bin/server list | cut -d '.' -f2| tr -d '\n')
+- build=$(grep "Open Liberty" target/liberty/wlp/usr/servers/"$serverName"/logs/console.log | cut -d' ' -f5 | cut -d')' -f1 ); release=$( echo "$build" | cut -d'/' -f1); number=$(echo "$build" | cut -d'/' -f2); ol_jv=$(grep -i "version" target/liberty/wlp/usr/servers/"$serverName"/logs/console.log); jv=$(printf '%s\n' "${ol_jv//$' on '/$'\n'}" | sed '2q;d'); echo -e "\n"; echo -e  "\033[1;34mOpen Liberty release:\033[0m \033[1;36m$release\033[0m"; echo -e "\033[1;34mOpen Liberty build number:\033[0m \033[1;36m$number\033[0m"; echo -e "\033[1;34mJava version:\033[0m\033[1;36m$jv\033[0m";
+- cd target/liberty/wlp/usr/servers/"$serverName"/logs/; repo_name=$(echo "$TRAVIS_REPO_SLUG" | sed -e "s/\//-/g"); if [ "$TRAVIS_TEST_RESULT" -eq 0 ]; then result="passed"; else result="failed"; fi; serverlogsarchive="$repo_name-$TRAVIS_BUILD_NUMBER-$result.zip";zip -r "$serverlogsarchive" .; curl -H "$JFROG_TOKEN" -T "$serverlogsarchive" "https://na.artifactory.swg-devops.com/artifactory/hyc-openliberty-guides-files-generic-local/";
 notifications:
   slack:
     template:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ before_script:
 - chmod +x ../scripts/travisTest.sh
 script: 
 - ../scripts/travisTest.sh
-- serverName=$(target/liberty/wlp/bin/server list | cut -d '.' -f2| tr -d '\n')
-- cd target/liberty/wlp/usr/servers/"$serverName"/logs/; repo_name=$(echo "$TRAVIS_REPO_SLUG" | sed -e "s/\//-/g"); if [ "$TRAVIS_TEST_RESULT" -eq 0 ]; then result="passed"; else result="failed"; fi; serverlogsarchive="$repo_name-$TRAVIS_BUILD_NUMBER-$result.zip";zip -r "$serverlogsarchive" .; curl -H "$JFROG_TOKEN" -T "$serverlogsarchive" "https://na.artifactory.swg-devops.com/artifactory/hyc-openliberty-guides-files-generic-local/";
 notifications:
   slack:
     template:

--- a/scripts/travisTest.sh
+++ b/scripts/travisTest.sh
@@ -28,14 +28,3 @@ docker stop gettingstarted-app && docker rm gettingstarted-app
 
 # TEST 2: Building and running the application
 mvn -q clean install
-
-serverName=$(target/liberty/wlp/bin/server list | cut -d '.' -f2| tr -d '\n')
-build=$(grep "Open Liberty" target/liberty/wlp/usr/servers/"$serverName"/logs/console.log | cut -d' ' -f5 | cut -d')' -f1 ) 
-release=$( echo "$build" | cut -d'/' -f1); number=$(echo "$build" | cut -d'/' -f2)
-ol_jv=$(grep -i "version" target/liberty/wlp/usr/servers/"$serverName"/logs/console.log) 
-jv=$(printf '%s\n' "${ol_jv//$' on '/$'\n'}" | sed '2q;d') 
-
-echo -e "\n"
-echo -e  "\033[1;34mOpen Liberty release:\033[0m \033[1;36m$release\033[0m"
-echo -e "\033[1;34mOpen Liberty build number:\033[0m \033[1;36m$number\033[0m" 
-echo -e "\033[1;34mJava version:\033[0m\033[1;36m$jv\033[0m"


### PR DESCRIPTION
Currently, the OL release, build number and java version are being printed twice. The results are also getting pushed to the artifactory twice. These steps are already done elsewhere in our automation and do not need to be done again here.