### PR TITLE
Removed spotify docker profile and plugin

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -455,26 +455,16 @@ what commands run when the image runs as a container, and so on. You can find a 
 `Dockerfile` in the `start` directory. This `Dockerfile` packages the `usr` server
 package into a Docker image that contains a preconfigured Open Liberty server.
 
-The [hotspot=58-81]`docker-image` profile uses the [hotspot=64]`dockerfile-maven` plug-in,
-which automatically builds a Docker image from a `Dockerfile` that is located in the same
-directory as the [hotspot]`pom.xml` file.
-
-pom.xml
-[source, XML, linenums, role="code_column"]
-----
-include::finish/pom.xml[tags=**]
-----
-
-To build and containerize the application, start your Docker daemon and then invoke the
-profile by using the `-P` flag:
+To build and containerize the application, start your Docker daemon and run the following command:
 
 [role='command']
 ```
-mvn clean package -P docker-image
+docker build -t openliberty-getting-started:1.0-SNAPSHOT .
 ```
 
-During the Maven `package` phase, a `usr` server package is generated into the `target`
-directory. The Docker `openliberty-getting-started:1.0-SNAPSHOT` image is also built from
+The `-t` flag in the `docker build` command allows the Docker image to be labeled (tagged) in the `name[:tag]` format. 
+The tag for an image describes the specific image version. If the optional `[:tag]` tag is not specified, the `latest` tag is created by default.
+ The Docker `openliberty-getting-started:1.0-SNAPSHOT` image is built from
 the `Dockerfile`. To verify that the image is built, run the `docker images` command to
 list all local Docker images:
 

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -23,7 +23,6 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <!-- Plugins -->
         <version.maven-war-plugin>3.2.2</version.maven-war-plugin>
-        <version.dockerfile-maven-plugin>1.4.10</version.dockerfile-maven-plugin>
         <version.maven-surefire-plugin>3.0.0-M1</version.maven-surefire-plugin>
         <version.maven-failsafe-plugin>3.0.0-M1</version.maven-failsafe-plugin>
         <!-- OpenLiberty runtime -->
@@ -59,32 +58,6 @@
                 <packaging.type>minify,runnable</packaging.type>
             </properties>
         </profile>
-        <!-- tag::profile-docker-image[] -->
-        <profile>
-            <id>docker-image</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <version>${version.dockerfile-maven-plugin}</version>
-                        <executions>
-                            <execution>
-                                <id>build-docker-image</id>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <repository>openliberty-${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <!-- end::profile-docker-image[] -->
     </profiles>
 
     <dependencyManagement>

--- a/scripts/travisTest.sh
+++ b/scripts/travisTest.sh
@@ -8,7 +8,9 @@ set -euxo pipefail
 ##############################################################################
 
 # TEST 1:  Running the application in a Docker container
-mvn -q clean package -P docker-image
+mvn -q clean package
+
+docker build -t openliberty-getting-started:1.0-SNAPSHOT .
 
 docker run -d --name gettingstarted-app -p 9080:9080 openliberty-getting-started:1.0-SNAPSHOT
 

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -23,7 +23,6 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <!-- Plugins -->
         <version.maven-war-plugin>3.2.2</version.maven-war-plugin>
-        <version.dockerfile-maven-plugin>1.4.10</version.dockerfile-maven-plugin>
         <version.maven-surefire-plugin>3.0.0-M1</version.maven-surefire-plugin>
         <version.maven-failsafe-plugin>3.0.0-M1</version.maven-failsafe-plugin>
         <!-- OpenLiberty runtime -->
@@ -59,32 +58,6 @@
                 <packaging.type>minify,runnable</packaging.type>
             </properties>
         </profile>
-        <!-- tag::profile-docker-image[] -->
-        <profile>
-            <id>docker-image</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <version>${version.dockerfile-maven-plugin}</version>
-                        <executions>
-                            <execution>
-                                <id>build-docker-image</id>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <repository>openliberty-${project.artifactId}</repository>
-                            <tag>${project.version}</tag>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <!-- end::profile-docker-image[] -->
     </profiles>
 
     <dependencyManagement>


### PR DESCRIPTION
Addressing https://github.com/OpenLiberty/guides-common/issues/299

- Removed Spotify docker profile plugin
- Ask user to use `docker build`
- Did not change app to be packaged into archive form and to use `ADD` because this guide is a special case