### PR TITLE
Travis test pull kernel OL

### DIFF
--- a/scripts/travisTest.sh
+++ b/scripts/travisTest.sh
@@ -10,7 +10,7 @@ set -euxo pipefail
 # TEST 1:  Running the application in a Docker container
 mvn -q clean package
 
-docker pull open-liberty
+docker pull openliberty/open-liberty:kernel-java8-openj9-ubi
 
 docker build -t openliberty-getting-started:1.0-SNAPSHOT .
 


### PR DESCRIPTION
https://github.com/OpenLiberty/guides-common/issues/439

Dockerfile changed to use `open-liberty` to `openliberty/open-liberty:kernel-java8-openj9-ubi`.
Need to adjust travis test accordingly.