### PR TITLE
Update dev mode with containers command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -504,7 +504,7 @@ endif::[]
 // Cloud hosted guide instruction
 ifdef::cloud-hosted[]
 ```
-mvn liberty:devc -DserverStatTimeout=300
+mvn liberty:devc -DserverStartTimeout=300
 ```
 {: codeblock}
 endif::[]

--- a/README.adoc
+++ b/README.adoc
@@ -493,10 +493,21 @@ configuration and rebuilds the image and restarts the container as necessary.
 
 Build and run the container by running the devc goal from the `start` directory:
 
+// Static guide instruction
+ifndef::cloud-hosted[]
+[role='command']
+```
+mvn liberty:devc
+```
+endif::[]
+
+// Cloud hosted guide instruction
+ifdef::cloud-hosted[]
 [role='command']
 ```
 mvn liberty:devc -DserverStatTimeout=300
 ```
+endif::[]
 
 When you see the following message, Open Liberty is ready to run in dev mode:
 

--- a/README.adoc
+++ b/README.adoc
@@ -503,10 +503,10 @@ endif::[]
 
 // Cloud hosted guide instruction
 ifdef::cloud-hosted[]
-[role='command']
 ```
 mvn liberty:devc -DserverStatTimeout=300
 ```
+{: codeblock}
 endif::[]
 
 When you see the following message, Open Liberty is ready to run in dev mode:

--- a/README.adoc
+++ b/README.adoc
@@ -495,7 +495,7 @@ Build and run the container by running the devc goal from the `start` directory:
 
 [role='command']
 ```
-mvn liberty:devc
+mvn liberty:devc -DserverStatTimeout=300
 ```
 
 When you see the following message, Open Liberty is ready to run in dev mode:


### PR DESCRIPTION
In the cloud hosted guides, the command to start the application using dev mode with containers fails on Skills Network because the server start times out. I found with an increased timeout, the application is able to start after about 3 minutes. I increase it to 5 minutes just to be safe, up from the default of 90 seconds. 

This change should only appear on the cloud hosted version of the guide. I tested on my Mac machine and the increased timeout was not necessary, with the application starting in about one minute.